### PR TITLE
Fix Red Room extra-hit bug and Black Room fake completion

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,6 @@
 //project name GUNGAME
 //Made by Joseph, Anthony
-//Date:2024-04-23
+//Date:2024-04-23         Updated: 2026-07-14
 //Description: using gitkraken and github and creating a game called GUNGAME.
 using GunGame.Core;
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A text-based console adventure game built in C# where you fight monsters, solve puzzles, and escape through a series of challenging rooms.
 
-> Made by Joseph & Anthony | April 2024
+> Made by Joseph Lodico and Anthony Vitalei-D'Ermes | April 2024 | Updated 2026-07-14
 
 ---
 

--- a/Rooms/BlackRoom.cs
+++ b/Rooms/BlackRoom.cs
@@ -8,6 +8,7 @@ namespace GunGame.Rooms
     {
         public override void Play(GameContext context)
         {
+            var player = context.Player;
             string[] codes = { "241-124-7645-653" };
             var stopwatch = new Stopwatch();
 
@@ -31,19 +32,20 @@ namespace GunGame.Rooms
                     Console.WriteLine("Code entered successfully within the time limit! ");
                     Console.WriteLine("YOU HAVE COMPLETED   THE BLACK ROOM!");
                     Console.WriteLine("===============================================");
+
+                    if (!context.CompletedRooms.Contains("black"))
+                    {
+                        context.CompletedRooms.Add("black");
+                    }
                 }
                 else
                 {
                     Console.WriteLine("Sorry, you either entered the wrong code or took too long. You failed to complete the black room.");
-                    break;
+                    player.HP = 0;
+                    return;
                 }
 
                 stopwatch.Reset();
-            }
-
-            if (context.CompletedRooms != null && !context.CompletedRooms.Contains("black"))
-            {
-                context.CompletedRooms.Add("black"); // Add completed room to the list
             }
         }
     }

--- a/Rooms/RedRoom.cs
+++ b/Rooms/RedRoom.cs
@@ -40,19 +40,22 @@ namespace GunGame.Rooms
                     Console.WriteLine(" Too bad!");
                     Console.WriteLine("===============================================");
                 }
-                // Enemy's turn to attack
-                int enemyRandomDamage = player.RollEnemyDamage(random);
-                Console.WriteLine("The goblin attacks you and does " + enemyRandomDamage + " damage!");
-                player.HP -= enemyRandomDamage;
-                Console.WriteLine("the Goblin now has " + goblin.HP + " HP left ");
-                Console.WriteLine("===============================================");
-                Console.WriteLine("and NOW you have " + player.HP + " HP left ");
-                Console.WriteLine("and  " + player.Bullets + " bullets left ");
                 if (goblin.HP <= 0)
                 {
                     Console.WriteLine("\n\n\tYou defeated the goblin!\n");
                     Console.WriteLine("===============================================");
                     Console.WriteLine("\nhere comes the Blob! NOW");
+                }
+                else
+                {
+                    // Enemy's turn to attack
+                    int enemyRandomDamage = player.RollEnemyDamage(random);
+                    Console.WriteLine("The goblin attacks you and does " + enemyRandomDamage + " damage!");
+                    player.HP -= enemyRandomDamage;
+                    Console.WriteLine("the Goblin now has " + goblin.HP + " HP left ");
+                    Console.WriteLine("===============================================");
+                    Console.WriteLine("and NOW you have " + player.HP + " HP left ");
+                    Console.WriteLine("and  " + player.Bullets + " bullets left ");
                 }
             }
 
@@ -83,6 +86,14 @@ namespace GunGame.Rooms
                     Console.WriteLine(" Too bad!");
                     Console.WriteLine("===============================================");
                 }
+                if (blob.HP <= 0)
+                {
+                    Console.WriteLine("\n\n\tYou defeated the blob!\n");
+                    Console.WriteLine("\nhere comes the Goomba! NOW");
+                    Console.WriteLine("===============================================");
+                    break;
+                }
+
                 // Enemy's turn to attack
                 int enemyRandomDamage = player.RollEnemyDamage(random);
                 Console.WriteLine("The blob attacks you and does " + enemyRandomDamage + " damage!");
@@ -91,14 +102,6 @@ namespace GunGame.Rooms
                 Console.WriteLine("===============================================");
                 Console.WriteLine("and NOW you have " + player.HP + " HP left ");
                 Console.WriteLine(" and  " + player.Bullets + " bullets left ");
-
-                if (blob.HP <= 0)
-                {
-                    Console.WriteLine("\n\n\tYou defeated the blob!\n");
-                    Console.WriteLine("\nhere comes the Goomba! NOW");
-                    Console.WriteLine("===============================================");
-                    break;
-                }
             }
 
             if (player.HP <= 0)
@@ -128,15 +131,6 @@ namespace GunGame.Rooms
                     Console.WriteLine(" Too bad!");
                     Console.WriteLine("===============================================");
                 }
-                // Enemy's turn to attack
-                int enemyRandomDamage = player.RollEnemyDamage(random);
-                Console.WriteLine("The goomba attacks you and does " + enemyRandomDamage + " damage!");
-                player.HP -= enemyRandomDamage;
-                Console.WriteLine(" The Goomba now has " + goomba.HP + " HP left ");
-                Console.WriteLine("===============================================");
-                Console.WriteLine("You NOW have " + player.HP + " HP left ");
-                Console.WriteLine("and " + player.Bullets + " bullets left ");
-
                 if (goomba.HP <= 0)
                 {
                     Console.WriteLine("\n\n\tYou defeated the Goomba! and you survived, GOOD WORK!\n");
@@ -145,6 +139,15 @@ namespace GunGame.Rooms
                     context.CompletedRooms.Add("red");
                     break;
                 }
+
+                // Enemy's turn to attack
+                int enemyRandomDamage = player.RollEnemyDamage(random);
+                Console.WriteLine("The goomba attacks you and does " + enemyRandomDamage + " damage!");
+                player.HP -= enemyRandomDamage;
+                Console.WriteLine(" The Goomba now has " + goomba.HP + " HP left ");
+                Console.WriteLine("===============================================");
+                Console.WriteLine("You NOW have " + player.HP + " HP left ");
+                Console.WriteLine("and " + player.Bullets + " bullets left ");
             }
         }
     }


### PR DESCRIPTION
## Summary
- Red Room let defeated enemies land one last attack before the victory message printed; enemies now only counter-attack while still alive, matching Blue Room's existing fix.
- Black Room marked itself completed even after a failed/timed-out code entry with no real consequence; failure now ends the game like the other rooms, and only a correct entry counts as completed.
- Updated README credits/date and a header comment.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [ ] Manual playthrough of Red Room and Black Room in a real terminal to confirm behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)