### PR TITLE
Show completed rooms in green and hide negative enemy HP

### DIFF
--- a/Core/GameEngine.cs
+++ b/Core/GameEngine.cs
@@ -86,15 +86,15 @@ namespace GunGame.Core
                 Console.WriteLine("Now Type the room color to  START or write gold to access your inventory");
 
                 Console.WriteLine("===============================================");
-                Console.WriteLine("1- [red door]");
+                WriteDoorOption("1- [red door]", "red");
                 Console.WriteLine("===============================================");
-                Console.WriteLine("2- [black door]");
+                WriteDoorOption("2- [black door]", "black");
                 Console.WriteLine("===============================================");
-                Console.WriteLine("3- [green door]");
+                WriteDoorOption("3- [green door]", "green");
                 Console.WriteLine("===============================================");
-                Console.WriteLine("4- [pink door]");
+                WriteDoorOption("4- [pink door]", "pink");
                 Console.WriteLine("===============================================");
-                Console.WriteLine("5- [blue door]");
+                WriteDoorOption("5- [blue door]", "blue");
                 Console.WriteLine("===============================================");
                 Console.WriteLine("6- [Locked door]");
                 Console.WriteLine("===============================================");
@@ -168,6 +168,20 @@ namespace GunGame.Core
             }
             Console.WriteLine("Congratulations! You have completed all the rooms!");
             SaveSystem.SaveGame(new GameData { playerHP = player.HP, bullets = player.Bullets });
+        }
+
+        private void WriteDoorOption(string label, string roomKey)
+        {
+            if (completedRooms.Contains(roomKey))
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine(label);
+                Console.ResetColor();
+            }
+            else
+            {
+                Console.WriteLine(label);
+            }
         }
     }
 }

--- a/Rooms/BlueRoom.cs
+++ b/Rooms/BlueRoom.cs
@@ -46,7 +46,10 @@ namespace GunGame.Rooms
                     int randomDamage = player.Shoot(random);
                     Console.WriteLine("You shoot at the SHADOW! You did " + randomDamage + " damage to the SHADOW.");
                     shadowClone.HP -= randomDamage;
-                    Console.WriteLine("The enemy now has " + shadowClone.HP + " hit points left!");
+                    if (shadowClone.HP > 0)
+                    {
+                        Console.WriteLine("The enemy now has " + shadowClone.HP + " hit points left!");
+                    }
                     Thread.Sleep(3000);
                     Console.Clear();
 

--- a/Rooms/RedRoom.cs
+++ b/Rooms/RedRoom.cs
@@ -31,7 +31,10 @@ namespace GunGame.Rooms
                     int randomDamage = player.Shoot(random);
                     Console.WriteLine("You shot at the goblin! You did " + randomDamage + " damage to the goblin.");
                     goblin.HP -= randomDamage;
-                    Console.WriteLine("The enemy now has " + goblin.HP + " hit points left!");
+                    if (goblin.HP > 0)
+                    {
+                        Console.WriteLine("The enemy now has " + goblin.HP + " hit points left!");
+                    }
                 }
                 else
                 {
@@ -76,7 +79,10 @@ namespace GunGame.Rooms
                     int randomDamage = player.Shoot(random);
                     Console.WriteLine("You shoot at the blob! You did " + randomDamage + " damage to the blob.");
                     blob.HP -= randomDamage;
-                    Console.WriteLine("The enemy now has " + blob.HP + " hit points left!");
+                    if (blob.HP > 0)
+                    {
+                        Console.WriteLine("The enemy now has " + blob.HP + " hit points left!");
+                    }
                 }
                 else
                 {
@@ -120,7 +126,10 @@ namespace GunGame.Rooms
                     int randomDamage = player.Shoot(random);
                     Console.WriteLine("You shoot at the goomba! You did " + randomDamage + " damage to the goomba.");
                     goomba.HP -= randomDamage;
-                    Console.WriteLine("The enemy now has " + goomba.HP + " hit points left!");
+                    if (goomba.HP > 0)
+                    {
+                        Console.WriteLine("The enemy now has " + goomba.HP + " hit points left!");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Door menu now highlights completed rooms in green.
- Red Room and Blue Room no longer print the enemy's negative HP on the killing blow; the existing defeat message covers it instead.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [ ] Manual playthrough in a real terminal to confirm colors and defeat messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)