### PR TITLE
Fix medkit exploit and free-turn bug in Blue Room

### DIFF
--- a/Core/Player.cs
+++ b/Core/Player.cs
@@ -26,7 +26,11 @@ namespace GunGame.Core
 
         public void UseMedkit()
         {
-            if (!MedkitUsed)
+            if (!MedkitPickedUp)
+            {
+                Console.WriteLine("You don't have a medkit to use.");
+            }
+            else if (!MedkitUsed)
             {
                 MedkitUsed = true;
                 HP += 55;

--- a/Rooms/BlueRoom.cs
+++ b/Rooms/BlueRoom.cs
@@ -70,7 +70,12 @@ namespace GunGame.Rooms
                 }
                 else if (userAction == 3)
                 {
+                    Console.Clear();
                     player.UseMedkit();
+                    int enemyDamage = player.RollEnemyDamage(random);
+                    Console.WriteLine("The SHADOW Attacks You, he does " + enemyDamage + " To You!");
+                    player.HP -= enemyDamage;
+                    Console.WriteLine("You Now have " + player.HP + " Hp Left!");
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Medkit could be used in the Blue Room without ever picking it up from the gold door — `UseMedkit()` now checks `MedkitPickedUp` and refuses to heal otherwise.
- Choosing the medkit option let the player skip the Shadow's counter-attack indefinitely with zero risk — it now costs a turn like every other action in that fight.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings/errors
- [ ] Manual playtest: enter Blue Room without visiting the gold door, confirm medkit option is refused
- [ ] Manual playtest: use medkit after picking it up, confirm Shadow still counter-attacks